### PR TITLE
Set npmMinimalAgeGate to 3d in .yarnrc.yml

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,4 +4,4 @@ enableScripts: true
 
 nodeLinker: node-modules
 
-npmMinimalAgeGate: 0
+npmMinimalAgeGate: "3d"


### PR DESCRIPTION
Changes `npmMinimalAgeGate` from `0` to `"3d"` in `.yarnrc.yml` to require packages to be at least 3 days old before being installed.